### PR TITLE
add trame display

### DIFF
--- a/tramex-tools/Cargo.toml
+++ b/tramex-tools/Cargo.toml
@@ -19,8 +19,7 @@ categories = ["visualization", "network-programming"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-debug = ["debug-trame"]
-debug-trame = []
+debug = []
 websocket = ["dep:ewebsock"]
 tokio = ["ewebsock/tokio"]
 

--- a/tramex-tools/src/connector.rs
+++ b/tramex-tools/src/connector.rs
@@ -205,7 +205,6 @@ impl Connector {
                                                 let trace = Trace {
                                                     trace_type: msg_type,
                                                     hexa: hexa.unwrap_or_default(),
-                                                    #[cfg(feature = "debug-trame")]
                                                     text: one_log.data,
                                                 };
                                                 self.data.events.push(trace);

--- a/tramex-tools/src/data.rs
+++ b/tramex-tools/src/data.rs
@@ -30,7 +30,6 @@ pub struct Trace {
     /// Hexadecimal representation of the message.
     pub hexa: Vec<u8>,
 
-    #[cfg(feature = "debug-trame")]
     /// Text representation of the message from the API
     pub text: Vec<String>,
 }

--- a/tramex-tools/src/file_handler.rs
+++ b/tramex-tools/src/file_handler.rs
@@ -159,7 +159,6 @@ impl File {
 
         let mut end = false;
         let mut brackets: i16 = 0;
-        #[cfg(feature = "debug-trame")]
         let start_block = *ix;
         while (*ix < lines_len) && !end {
             brackets += Self::count_brackets(lines[*ix]);
@@ -177,7 +176,6 @@ impl File {
         let trace = Trace {
             trace_type: mtype,
             hexa: hex,
-            #[cfg(feature = "debug-trame")]
             text: lines[start_block..*ix].iter().map(|&s| s.to_string()).collect(),
         };
         *ix += 1;

--- a/tramex/src/app.rs
+++ b/tramex/src/app.rs
@@ -19,8 +19,11 @@ pub struct TramexApp {
     /// Error panel
     error_panel: Vec<TramexError>,
 
-    /// Show about
-    show_about: bool,
+    /// Show about windows
+    show_about_windows: bool,
+
+    /// Show about windows
+    show_options_windows: bool,
 }
 
 impl TramexApp {
@@ -46,7 +49,10 @@ impl TramexApp {
                 ui.ctx().memory_mut(|mem| mem.reset_areas());
             }
             if ui.button("About").clicked() {
-                self.show_about = !self.show_about;
+                self.show_about_windows = !self.show_about_windows;
+            }
+            if ui.button("Options").clicked() {
+                self.show_options_windows = !self.show_options_windows;
             }
             #[cfg(not(target_arch = "wasm32"))]
             {
@@ -105,7 +111,7 @@ impl TramexApp {
     /// Display the about windows
     fn ui_about_windows(&mut self, ctx: &egui::Context) {
         egui::Window::new("About")
-            .open(&mut self.show_about)
+            .open(&mut self.show_about_windows)
             .resizable([true, true])
             .show(ctx, |ui| {
                 ui.with_layout(egui::Layout::top_down(egui::Align::Center), |ui| {
@@ -141,7 +147,17 @@ impl TramexApp {
                             ""
                         }
                     ));
-                    ui.separator();
+                });
+            });
+    }
+
+    /// Display the options windows
+    fn ui_options_windows(&mut self, ctx: &egui::Context) {
+        egui::Window::new("Options")
+            .open(&mut self.show_options_windows)
+            .resizable([true, true])
+            .show(ctx, |ui| {
+                ui.with_layout(egui::Layout::top_down(egui::Align::Center), |ui| {
                     self.frontend.ui_about(ui);
                 });
             });
@@ -153,7 +169,8 @@ impl Default for TramexApp {
         Self {
             frontend: FrontEnd::new(),
             error_panel: vec![],
-            show_about: false,
+            show_about_windows: false,
+            show_options_windows: false,
         }
     }
 }
@@ -176,8 +193,11 @@ impl eframe::App for TramexApp {
         }
 
         self.ui_error_panel(ctx);
-        if self.show_about {
+        if self.show_about_windows {
             self.ui_about_windows(ctx);
+        }
+        if self.show_options_windows {
+            self.ui_options_windows(ctx);
         }
     }
 }

--- a/tramex/src/frontend.rs
+++ b/tramex/src/frontend.rs
@@ -87,6 +87,7 @@ impl FrontEnd {
 
     /// Show tiny ui in about panel
     pub fn ui_about(&mut self, ui: &mut egui::Ui) {
+        ui.label("Index of files URL:");
         ui.add(egui::TextEdit::singleline(&mut self.url_files));
     }
 

--- a/tramex/src/panels/message.rs
+++ b/tramex/src/panels/message.rs
@@ -10,12 +10,18 @@ use tramex_tools::errors::TramexError;
 pub struct MessageBox {
     /// Reference to the data
     data: Rc<RefCell<Connector>>,
+
+    /// show full message
+    show_full: bool,
 }
 
 impl MessageBox {
     /// Create a new MessageBox
     pub fn new(ref_data: Rc<RefCell<Connector>>) -> Self {
-        Self { data: ref_data }
+        Self {
+            data: ref_data,
+            show_full: false,
+        }
     }
 }
 
@@ -44,6 +50,7 @@ impl super::PanelController for MessageBox {
 impl super::PanelView for MessageBox {
     fn ui(&mut self, ui: &mut egui::Ui) {
         ui.heading("Received events:");
+        ui.checkbox(&mut self.show_full, "Show full message");
         let borrowed = &self.data.borrow();
         let events = &borrowed.data.events;
         ui.horizontal(|ui| {
@@ -53,7 +60,7 @@ impl super::PanelView for MessageBox {
 
         if let Some(one_log) = events.get(current_index) {
             ui.label(format!("Current msg index: {}", current_index + 1));
-            display_log(ui, one_log);
+            display_log(ui, one_log, self.show_full);
         }
     }
 }

--- a/tramex/src/utils.rs
+++ b/tramex/src/utils.rs
@@ -42,16 +42,18 @@ pub fn color_label(job: &mut LayoutJob, ui: &Ui, label: &str, need_color: bool) 
 }
 
 /// Display a Trace type
-pub fn display_log(ui: &mut Ui, curr_trace: &Trace) {
+pub fn display_log(ui: &mut Ui, curr_trace: &Trace, full: bool) {
     ui.label(format!("{:?}", &curr_trace.trace_type));
     ui.label(format!("{:?}", &curr_trace.hexa));
-    #[cfg(feature = "debug")]
-    {
+    if full {
         ui.separator();
-        egui::ScrollArea::vertical().show(ui, |ui| {
-            for elem in &curr_trace.text {
-                ui.label(elem);
-            }
-        });
+        egui::ScrollArea::vertical()
+            .max_height(300.0)
+            .auto_shrink([false, true])
+            .show(ui, |ui| {
+                for elem in &curr_trace.text {
+                    ui.label(elem);
+                }
+            });
     }
 }


### PR DESCRIPTION
Also add a "options" windows <- could be useful for later


currently not the best system : the "show full is in the panel", i think the best would be to conditionnaly add `text` to `Trame` if enabled (currently we always add the `text`)